### PR TITLE
build: rollback to emsdk@2

### DIFF
--- a/packages/avif/codec/dec/avif_dec.js
+++ b/packages/avif/codec/dec/avif_dec.js
@@ -29,10 +29,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/avif/codec/enc/avif_enc.js
+++ b/packages/avif/codec/enc/avif_enc.js
@@ -29,10 +29,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/avif/codec/pre.js
+++ b/packages/avif/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/jpeg/codec/Makefile
+++ b/packages/jpeg/codec/Makefile
@@ -16,7 +16,10 @@ all: $(OUT_JS)
 $(filter enc/%,$(OUT_JS)): enc/mozjpeg_enc.cpp
 $(filter dec/%,$(OUT_JS)): dec/mozjpeg_dec.cpp
 
-%.js: $(CODEC_OUT)
+$(PRE_JS):
+	touch $@
+
+%.js: $(CODEC_OUT) $(PRE_JS)
 	$(CXX) \
 		-I $(CODEC_DIR) \
 		${CXXFLAGS} \
@@ -28,7 +31,7 @@ $(filter dec/%,$(OUT_JS)): dec/mozjpeg_dec.cpp
 		-s DYNAMIC_EXECUTION=0 \
 		-s MODULARIZE=1 \
 		-o $@ \
-		$+
+		$(CODEC_OUT)
 
 # This one is a bit special: there is no rule for .libs/libjpeg.a
 #  so we use libjpeg.la which implicitly builds that one instead.

--- a/packages/jpeg/codec/package.json
+++ b/packages/jpeg/codec/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "EMSDK_VERSION=3.1.57 ../../../tools/build-cpp.sh"
+    "build": "../../../tools/build-cpp.sh"
   },
   "type": "module"
 }

--- a/packages/jpeg/codec/pre.js
+++ b/packages/jpeg/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/jxl/codec/pre.js
+++ b/packages/jxl/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/oxipng/codec/pkg-parallel/squoosh_oxipng.js
+++ b/packages/oxipng/codec/pkg-parallel/squoosh_oxipng.js
@@ -354,10 +354,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/oxipng/codec/pkg/squoosh_oxipng.js
+++ b/packages/oxipng/codec/pkg/squoosh_oxipng.js
@@ -196,10 +196,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/oxipng/codec/pre.js
+++ b/packages/oxipng/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/png/codec/pkg/squoosh_png.js
+++ b/packages/png/codec/pkg/squoosh_png.js
@@ -230,10 +230,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/png/codec/pre.js
+++ b/packages/png/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/resize/lib/hqx/pkg/squooshhqx.js
+++ b/packages/resize/lib/hqx/pkg/squooshhqx.js
@@ -159,10 +159,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/resize/lib/hqx/pre.js
+++ b/packages/resize/lib/hqx/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/resize/lib/resize/pkg/squoosh_resize.js
+++ b/packages/resize/lib/resize/pkg/squoosh_resize.js
@@ -173,10 +173,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/resize/lib/resize/pre.js
+++ b/packages/resize/lib/resize/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }

--- a/packages/webp/codec/pre.js
+++ b/packages/webp/codec/pre.js
@@ -14,10 +14,6 @@ if (isRunningInCloudFlareWorkers || isRunningInNode) {
     };
   }
 
-  if (import.meta.url === undefined) {
-    import.meta.url = 'https://localhost';
-  }
-
   if (typeof self !== 'undefined' && self.location === undefined) {
     self.location = { href: '' };
   }


### PR DESCRIPTION
emsdk@3 does not build so use emsdk@2 for now. terser fails on import.meta syntax. NodeJS 18 (lowest LTS version) supports import.meta.url so that block isn't needed anyway.