### PR TITLE
feat: improve providing only module options to init methods

### DIFF
--- a/packages/avif/CHANGELOG.md
+++ b/packages/avif/CHANGELOG.md
@@ -13,6 +13,24 @@
     - When `lossless` is set to `true`, the `quality` and `qualityAlpha` options are ignored
     - The `subsample` option is ignored when `lossless` is set to `true`
 
+- Adds support for only providing a module option override to the `init` function directly
+
+  **Example:**
+  ```ts
+  import encode, { init } from '@jsquash/avif/encode';
+  await init({
+    locateFile: (path) => {
+        const remoteLocation = 'https://cdn.mydomain.com/wasm';
+        return remoteLocation + path;
+    }
+  });
+  const buffer = await encode(/* image data */);
+  ```
+
+### Fixes
+
+- Updates `locateFile` emscripten module option type to support prefix parameter.
+
 ## @jsquash/avif@2.0.0
 
 ### Breaking Changes

--- a/packages/avif/decode.ts
+++ b/packages/avif/decode.ts
@@ -25,13 +25,26 @@ import { ImageData16bit } from 'meta.js';
 let emscriptenModule: Promise<AVIFModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<void>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<void> {
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
   emscriptenModule = initEmscriptenModule(
     avif_dec,
-    module,
-    moduleOptionOverrides,
+    actualModule,
+    actualOptions,
   );
 }
 

--- a/packages/avif/emscripten-types.d.ts
+++ b/packages/avif/emscripten-types.d.ts
@@ -12,7 +12,9 @@ declare namespace EmscriptenWasm {
   interface ModuleOpts {
     mainScriptUrlOrBlob?: string;
     noInitialRun?: boolean;
-    locateFile?: (url: string) => string;
+    locateFile?:
+      | ((path: string) => string)
+      | ((path: string, prefix: string) => string);
     onRuntimeInitialized?: () => void;
     instantiateWasm?: (
       imports: WebAssembly.Imports,

--- a/packages/jpeg/CHANGELOG.md
+++ b/packages/jpeg/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## @jsquash/jpeg@1.6.0
+
+### Adds
+
+- Adds support for only providing a module option override to the `init` function directly
+
+  **Example:**
+  ```ts
+  import encode, { init } from '@jsquash/jpeg/encode';
+  await init({
+    locateFile: (path) => {
+        const remoteLocation = 'https://cdn.mydomain.com/wasm';
+        return remoteLocation + path;
+    }
+  });
+  const buffer = await encode(/* image data */);
+  ```
+
+### Fixes
+
+- Updates `locateFile` emscripten module option type to support prefix parameter.
+
 ## @jsquash/jpeg@1.5.0
 
 ### Adds

--- a/packages/jpeg/decode.ts
+++ b/packages/jpeg/decode.ts
@@ -25,13 +25,26 @@ import { DecodeOptions, defaultDecodeOptions } from './meta.js';
 let emscriptenModule: Promise<MozJPEGModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<void>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<void> {
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
   emscriptenModule = initEmscriptenModule(
     mozjpeg_dec,
-    module,
-    moduleOptionOverrides,
+    actualModule,
+    actualOptions,
   );
 }
 

--- a/packages/jpeg/emscripten-types.d.ts
+++ b/packages/jpeg/emscripten-types.d.ts
@@ -12,7 +12,9 @@ declare namespace EmscriptenWasm {
   interface ModuleOpts {
     mainScriptUrlOrBlob?: string;
     noInitialRun?: boolean;
-    locateFile?: (url: string) => string;
+    locateFile?:
+      | ((path: string) => string)
+      | ((path: string, prefix: string) => string);
     onRuntimeInitialized?: () => void;
     instantiateWasm?: (
       imports: WebAssembly.Imports,

--- a/packages/jpeg/encode.ts
+++ b/packages/jpeg/encode.ts
@@ -26,13 +26,26 @@ import { initEmscriptenModule } from './utils.js';
 let emscriptenModule: Promise<MozJPEGModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<void>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<void> {
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
   emscriptenModule = initEmscriptenModule(
     mozjpeg_enc,
-    module,
-    moduleOptionOverrides,
+    actualModule,
+    actualOptions,
   );
 }
 
@@ -50,6 +63,6 @@ export default async function encode(
     data.height,
     _options,
   );
-  // wasm can’t run on SharedArrayBuffers, so we hard-cast to ArrayBuffer.
+  // wasm can't run on SharedArrayBuffers, so we hard-cast to ArrayBuffer.
   return resultView.buffer as ArrayBuffer;
 }

--- a/packages/jpeg/package.json
+++ b/packages/jpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsquash/jpeg",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "index.js",
   "description": "Wasm jpeg encoder and decoder supporting the browser. Repackaged from Squoosh App.",
   "repository": "jamsinclair/jSquash",

--- a/packages/jxl/CHANGELOG.md
+++ b/packages/jxl/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## @jsquash/jxl@1.2.0
+
+### Adds
+- Adds support for only providing a module option override to the `init` function directly
+
+  **Example:**
+  ```ts
+  import encode, { init } from '@jsquash/jxl/encode';
+  await init({
+    locateFile: (path) => {
+        const remoteLocation = 'https://cdn.mydomain.com/wasm';
+        return remoteLocation + path;
+    }
+  });
+  const buffer = await encode(/* image data */);
+  ```
+
+### Fixes
+
+- Updates `locateFile` emscripten module option type to support prefix parameter.
+
 ## @jsquash/jxl@1.1.0
 
 ### Adds

--- a/packages/jxl/decode.ts
+++ b/packages/jxl/decode.ts
@@ -22,13 +22,26 @@ import { initEmscriptenModule } from './utils.js';
 let emscriptenModule: Promise<JXLModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<JXLModule>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<JXLModule> {
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
   emscriptenModule = initEmscriptenModule(
     jxlDecoder,
-    module,
-    moduleOptionOverrides,
+    actualModule,
+    actualOptions,
   );
   return emscriptenModule;
 }

--- a/packages/jxl/emscripten-types.d.ts
+++ b/packages/jxl/emscripten-types.d.ts
@@ -12,7 +12,9 @@ declare namespace EmscriptenWasm {
   interface ModuleOpts {
     mainScriptUrlOrBlob?: string;
     noInitialRun?: boolean;
-    locateFile?: (url: string) => string;
+    locateFile?:
+      | ((path: string) => string)
+      | ((path: string, prefix: string) => string);
     onRuntimeInitialized?: () => void;
     instantiateWasm?: (
       imports: WebAssembly.Imports,

--- a/packages/jxl/package.json
+++ b/packages/jxl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsquash/jxl",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "description": "Wasm JPEG XL encoder and decoder supporting the browser. Repackaged from Squoosh App.",
   "repository": "jamsinclair/jSquash",

--- a/packages/qoi/CHANGELOG.md
+++ b/packages/qoi/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## @jsquash/qoi@1.1.0
+
+### Adds
+
+- Adds support for only providing a module option override to the `init` function directly
+
+  **Example:**
+  ```ts
+  import encode, { init } from '@jsquash/qoi/encode';
+  await init({
+    locateFile: (path) => {
+        const remoteLocation = 'https://cdn.mydomain.com/wasm';
+        return remoteLocation + path;
+    }
+  });
+  const buffer = await encode(/* image data */);
+  ```
+
+### Fixes
+
+- Updates `locateFile` emscripten module option type to support prefix parameter.
+
 ## @jsquash/qoi@1.0.0
 
 ### Adds

--- a/packages/qoi/decode.ts
+++ b/packages/qoi/decode.ts
@@ -24,14 +24,23 @@ import qoi_dec from './codec/dec/qoi_dec.js';
 let emscriptenModule: Promise<QOIModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<void>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<void> {
-  emscriptenModule = initEmscriptenModule(
-    qoi_dec,
-    module,
-    moduleOptionOverrides,
-  );
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
+  emscriptenModule = initEmscriptenModule(qoi_dec, actualModule, actualOptions);
 }
 
 export default async function decode(buffer: ArrayBuffer): Promise<ImageData> {

--- a/packages/qoi/emscripten-types.d.ts
+++ b/packages/qoi/emscripten-types.d.ts
@@ -12,7 +12,9 @@ declare namespace EmscriptenWasm {
   interface ModuleOpts {
     mainScriptUrlOrBlob?: string;
     noInitialRun?: boolean;
-    locateFile?: (url: string) => string;
+    locateFile?:
+      | ((path: string) => string)
+      | ((path: string, prefix: string) => string);
     onRuntimeInitialized?: () => void;
     instantiateWasm?: (
       imports: WebAssembly.Imports,

--- a/packages/qoi/package.json
+++ b/packages/qoi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsquash/qoi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "description": "Wasm Quite Ok Image Format (qoi) encoder and decoder supporting the browser. Repackaged from Squoosh App.",
   "repository": "jamsinclair/jSquash",

--- a/packages/webp/CHANGELOG.md
+++ b/packages/webp/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## @jsquash/webp@1.5.0
+
+### Adds
+
+- Adds support for only providing a module option override to the `init` function directly
+
+  **Example:**
+  ```ts
+  import encode, { init } from '@jsquash/webp/encode';
+  await init({
+    locateFile: (path) => {
+        const remoteLocation = 'https://cdn.mydomain.com/wasm';
+        return remoteLocation + path;
+    }
+  });
+  const buffer = await encode(/* image data */);
+  ```
+
+### Fixes
+
+- Updates `locateFile` emscripten module option type to support prefix parameter.
+
 ## @jsquash/webp@1.4.0
 
 ### Adds

--- a/packages/webp/decode.ts
+++ b/packages/webp/decode.ts
@@ -23,13 +23,26 @@ import { initEmscriptenModule } from './utils.js';
 let emscriptenModule: Promise<WebPModule>;
 
 export async function init(
+  moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
+): Promise<void>;
+export async function init(
   module?: WebAssembly.Module,
   moduleOptionOverrides?: Partial<EmscriptenWasm.ModuleOpts>,
 ): Promise<void> {
+  let actualModule: WebAssembly.Module | undefined = module;
+  let actualOptions: Partial<EmscriptenWasm.ModuleOpts> | undefined =
+    moduleOptionOverrides;
+
+  // If only one argument is provided and it's not a WebAssembly.Module
+  if (arguments.length === 1 && !(module instanceof WebAssembly.Module)) {
+    actualModule = undefined;
+    actualOptions = module as unknown as Partial<EmscriptenWasm.ModuleOpts>;
+  }
+
   emscriptenModule = initEmscriptenModule(
     webp_dec,
-    module,
-    moduleOptionOverrides,
+    actualModule,
+    actualOptions,
   );
 }
 

--- a/packages/webp/emscripten-types.d.ts
+++ b/packages/webp/emscripten-types.d.ts
@@ -12,7 +12,9 @@ declare namespace EmscriptenWasm {
   interface ModuleOpts {
     mainScriptUrlOrBlob?: string;
     noInitialRun?: boolean;
-    locateFile?: (url: string) => string;
+    locateFile?:
+      | ((path: string) => string)
+      | ((path: string, prefix: string) => string);
     onRuntimeInitialized?: () => void;
     instantiateWasm?: (
       imports: WebAssembly.Imports,

--- a/packages/webp/package.json
+++ b/packages/webp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsquash/webp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "index.js",
   "description": "Wasm webp encoder and decoder supporting the browser. Repackaged from Squoosh App.",
   "repository": "jamsinclair/jSquash",


### PR DESCRIPTION
Relates to #84 

It was highlighted in issue #84 that it is awkward to provide modules options ONLY to init methods.

**Changes:**
- Allows providing only the module options object to the `init` methods
- Updates the typing for `locateFile` to also support the `prefix` param. 