### PR TITLE
fix: png wasm module init

### DIFF
--- a/packages/png/decode.ts
+++ b/packages/png/decode.ts
@@ -26,7 +26,7 @@ import initPngModule, {
   decode_rgba16 as pngDecodeRgba16Wasm,
 } from './codec/pkg/squoosh_png.js';
 
-let pngModule: Promise<PngModule>;
+let pngModule: PngModule;
 
 export interface DecodeOptions {
   bitDepth?: 8 | 16;
@@ -34,7 +34,7 @@ export interface DecodeOptions {
 
 export async function init(moduleOrPath?: InitInput): Promise<PngModule> {
   if (!pngModule) {
-    pngModule = initPngModule(moduleOrPath);
+    pngModule = await initPngModule(moduleOrPath);
   }
 
   return pngModule;

--- a/packages/png/encode.ts
+++ b/packages/png/encode.ts
@@ -28,11 +28,11 @@ type ImageDataRGBA16 = {
   height: number;
 };
 
-let pngModule: Promise<PngModule>;
+let pngModule: PngModule;
 
 export async function init(moduleOrPath?: InitInput): Promise<PngModule> {
   if (!pngModule) {
-    pngModule = initPngModule(moduleOrPath);
+    pngModule = await initPngModule(moduleOrPath);
   }
 
   return pngModule;


### PR DESCRIPTION
The initialization process was not completed during the first PNG decoding call. 
After modifying the relevant code section, the functionality now works as expected. 
However, I'm unclear why the original code appeared to be logically correct.

```
Uncaught (in promise) TypeError: Failed to execute 'compile' on 'WebAssembly': An argument must be provided, which must be a Response or Promise<Response> object
```

