### PR TITLE
feat: add lossless option to jxl package

### DIFF
--- a/packages/avif/README.md
+++ b/packages/avif/README.md
@@ -85,6 +85,17 @@ const rawImageData = await loadImage('/example.png');
 const avifBuffer = await encode(rawImageData, { lossless: true });
 ```
 
+## Activate Multithreading
+
+By default, the encode function will use a single thread to encode the image. If you want to speed this up you can enable multithreading with the following.
+
+1. Move your calls to `encode` into a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers).
+1. Configure your web server to use the following headers (this is [a security requirement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements))
+    - `Cross-Origin-Opener-Policy: same-origin`
+    - `Cross-Origin-Embedder-Policy: require-corp`
+
+This will still only take effect in browsers and devices that support multithreading. If the browser does not support it, it will fallback to single threaded mode
+
 ## Manual WASM initialisation (not recommended)
 
 In most situations there is no need to manually initialise the provided WebAssembly modules.

--- a/packages/jxl/CHANGELOG.md
+++ b/packages/jxl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## @jsquash/jxl@1.2.1
+
+### Fixes
+
+- Adds a convenience option to set lossless encoding (`encode(imageData, { lossless: true })`)
+
 ## @jsquash/jxl@1.2.0
 
 ### Adds

--- a/packages/jxl/README.md
+++ b/packages/jxl/README.md
@@ -69,6 +69,26 @@ const rawImageData = await loadImage('/example.png');
 const jpegBuffer = await encode(rawImageData);
 ```
 
+#### Lossless Example
+```js
+import { encode } from '@jsquash/jxl';
+
+const rawImageData = await loadImage('/example.png');
+// Lossless encoding can be achieved by setting the `lossless` option to `true`
+const jpegBuffer = await encode(rawImageData, { lossless: true });
+```
+
+## Activate Multithreading
+
+By default, the encode function will use a single thread to encode the image. If you want to speed this up you can enable multithreading with the following.
+
+1. Move your calls to `encode` into a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers).
+1. Configure your web server to use the following headers (this is [a security requirement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements))
+    - `Cross-Origin-Opener-Policy: same-origin`
+    - `Cross-Origin-Embedder-Policy: require-corp`
+
+This will still only take effect in browsers and devices that support multithreading. If the browser does not support it, it will fallback to single threaded mode
+
 ## Manual WASM initialisation (not recommended)
 
 In most situations there is no need to manually initialise the provided WebAssembly modules.

--- a/packages/jxl/README.md
+++ b/packages/jxl/README.md
@@ -75,7 +75,7 @@ import { encode } from '@jsquash/jxl';
 
 const rawImageData = await loadImage('/example.png');
 // Lossless encoding can be achieved by setting the `lossless` option to `true`
-const jpegBuffer = await encode(rawImageData, { lossless: true });
+const jxlBuffer = await encode(rawImageData, { lossless: true });
 ```
 
 ## Activate Multithreading

--- a/packages/jxl/codec/enc/jxl_enc.d.ts
+++ b/packages/jxl/codec/enc/jxl_enc.d.ts
@@ -7,6 +7,7 @@ export interface EncodeOptions {
   decodingSpeedTier: number;
   photonNoiseIso: number;
   lossyModular: boolean;
+  lossless: boolean;
 }
 
 export interface JXLModule extends EmscriptenWasm.Module {

--- a/packages/jxl/encode.ts
+++ b/packages/jxl/encode.ts
@@ -88,6 +88,31 @@ export default async function encode(
 
   const module = await emscriptenModule;
   const _options = { ...defaultOptions, ...options };
+
+  if (_options.lossless) {
+    if (options.quality !== undefined && options.quality !== 100) {
+      console.warn(
+        'JXL lossless: Quality setting is ignored when lossless is enabled (quality must be 100).',
+      );
+    }
+
+    if (options.lossyModular) {
+      console.warn(
+        'JXL lossless: LossyModular setting is ignored when lossless is enabled (lossyModular must be false).',
+      );
+    }
+
+    if (options.lossyPalette) {
+      console.warn(
+        'JXL lossless: LossyPalette setting is ignored when lossless is enabled (lossyPalette must be false).',
+      );
+    }
+
+    _options.quality = 100;
+    _options.lossyModular = false;
+    _options.lossyPalette = false;
+  }
+
   const resultView = module.encode(
     data.data,
     data.width,

--- a/packages/jxl/meta.ts
+++ b/packages/jxl/meta.ts
@@ -26,4 +26,5 @@ export const defaultOptions: EncodeOptions = {
   decodingSpeedTier: 0,
   photonNoiseIso: 0,
   lossyModular: false,
+  lossless: false,
 };

--- a/packages/jxl/package.json
+++ b/packages/jxl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsquash/jxl",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "description": "Wasm JPEG XL encoder and decoder supporting the browser. Repackaged from Squoosh App.",
   "repository": "jamsinclair/jSquash",

--- a/test/node/jxl.test.ts
+++ b/test/node/jxl.test.ts
@@ -29,3 +29,78 @@ test('can successfully encode image', async (t) => {
   });
   t.assert(data instanceof ArrayBuffer);
 });
+
+test('can successfully encode and decode lossless image', async (t) => {
+  const [encodeWasmModule, decodeWasmModule] = await Promise.all([
+    importWasmModule('node_modules/@jsquash/jxl/codec/enc/jxl_enc.wasm'),
+    importWasmModule('node_modules/@jsquash/jxl/codec/dec/jxl_dec.wasm'),
+  ]);
+  await initEncode(encodeWasmModule);
+  initDecode(decodeWasmModule);
+
+  const originalImageData = {
+    width: 10,
+    height: 10,
+    data: new Uint8ClampedArray(4 * 10 * 10),
+    colorSpace: 'srgb' as const,
+  };
+  // Fill with some non-zero data
+  for (let i = 0; i < originalImageData.data.length; i++) {
+    originalImageData.data[i] = (i * 3 + 7) % 256;
+  }
+
+  const encodedData = await encode(originalImageData, { lossless: true });
+  t.assert(encodedData instanceof ArrayBuffer);
+
+  const decodedData = await decode(encodedData);
+  if (!decodedData) {
+    t.fail('Failed to decode image');
+    return;
+  }
+
+  t.is(decodedData.width, originalImageData.width);
+  t.is(decodedData.height, originalImageData.height);
+  t.deepEqual(
+    decodedData.data,
+    originalImageData.data,
+    'Decoded data should match original for lossless',
+  );
+});
+
+test('encodes lossless even with conflicting quality option', async (t) => {
+  const [encodeWasmModule, decodeWasmModule] = await Promise.all([
+    importWasmModule('node_modules/@jsquash/jxl/codec/enc/jxl_enc.wasm'),
+    importWasmModule('node_modules/@jsquash/jxl/codec/dec/jxl_dec.wasm'),
+  ]);
+  await initEncode(encodeWasmModule);
+  initDecode(decodeWasmModule);
+
+  const originalImageData = {
+    width: 8,
+    height: 8,
+    data: new Uint8ClampedArray(4 * 8 * 8),
+    colorSpace: 'srgb' as const,
+  };
+  for (let i = 0; i < originalImageData.data.length; i++) {
+    originalImageData.data[i] = (i * 5) % 256;
+  }
+
+  // Encode with lossless true but also a lossy quality setting
+  const encodedData = await encode(originalImageData, {
+    lossless: true,
+    quality: 50,
+  });
+  t.assert(encodedData instanceof ArrayBuffer);
+
+  const decodedData = await decode(encodedData);
+  if (!decodedData) {
+    t.fail('Failed to decode image');
+    return;
+  }
+
+  t.deepEqual(
+    decodedData.data,
+    originalImageData.data,
+    'Decoded data should match original even with conflicting quality',
+  );
+});


### PR DESCRIPTION
Fixes #93 

- Adds lossless option for `jxl` encode method
- Update README with lossless instructions
- For both JXL and AVIF add a README section for how to get multi-threading to work.