### PR TITLE
feat: add GIF decoder using Rust gif crate

### DIFF
--- a/examples/gif-decode/index.html
+++ b/examples/gif-decode/index.html
@@ -5,64 +5,201 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>jSquash GIF Decoder Example</title>
   <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
     body {
-      font-family: system-ui, sans-serif;
-      max-width: 800px;
-      margin: 2rem auto;
-      padding: 0 1rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+      background: #f8f9fa;
+      color: #1a1a1a;
     }
-    canvas {
-      border: 1px solid #ccc;
-      display: block;
+
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0 0 0.25rem;
+    }
+
+    h1 span { color: #666; font-weight: 400; }
+
+    .subtitle {
+      color: #888;
+      font-size: 0.85rem;
+      margin: 0 0 1.5rem;
+    }
+
+    .drop-zone {
+      border: 2px dashed #ccc;
+      border-radius: 8px;
+      padding: 2.5rem;
+      text-align: center;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      background: #fff;
+    }
+
+    .drop-zone:hover, .drop-zone.dragover {
+      border-color: #4a90d9;
+      background: #f0f6ff;
+    }
+
+    .drop-zone p {
+      margin: 0;
+      color: #666;
+      font-size: 0.95rem;
+    }
+
+    .drop-zone input[type="file"] { display: none; }
+
+    #status {
       margin: 1rem 0;
+      padding: 0.6rem 1rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      background: #e8f4fd;
+      color: #1a6fa8;
+      display: none;
+    }
+
+    #status.error {
+      background: #fde8e8;
+      color: #a81a1a;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 1.25rem;
+      margin: 1rem 0;
+    }
+
+    .card h2 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #555;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin: 0 0 0.75rem;
+    }
+
+    .card-meta {
+      font-size: 0.8rem;
+      color: #888;
+      margin: 0.5rem 0 0;
+    }
+
+    .canvas-wrap {
+      display: flex;
+      justify-content: center;
+      background: repeating-conic-gradient(#e8e8e8 0% 25%, #fff 0% 50%) 0 0 / 16px 16px;
+      border-radius: 4px;
+      padding: 1rem;
+      overflow: auto;
+    }
+
+    .canvas-wrap canvas {
+      display: block;
+      image-rendering: pixelated;
+      max-width: 100%;
+      height: auto;
+    }
+
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.75rem;
+    }
+
+    .controls button {
+      padding: 0.35rem 1rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 0.85rem;
+      transition: background 0.1s;
+    }
+
+    .controls button:hover { background: #f3f4f6; }
+
+    #frame-info {
+      font-size: 0.8rem;
+      color: #888;
+      margin: 0;
+    }
+
+    .filmstrip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 0.75rem;
+    }
+
+    .filmstrip-frame {
+      position: relative;
+      border: 2px solid transparent;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: border-color 0.1s;
+      overflow: hidden;
+      background: repeating-conic-gradient(#e8e8e8 0% 25%, #fff 0% 50%) 0 0 / 8px 8px;
+    }
+
+    .filmstrip-frame:hover { border-color: #93c5fd; }
+    .filmstrip-frame.active { border-color: #4a90d9; }
+
+    .filmstrip-frame canvas {
+      display: block;
       image-rendering: pixelated;
     }
-    #status {
-      color: #666;
-      margin: 0.5rem 0;
-    }
-    #controls {
-      margin: 1rem 0;
-    }
-    #controls button {
-      margin-right: 0.5rem;
-    }
-    #frame-info {
-      font-size: 0.9rem;
-      color: #444;
-    }
-    .section {
-      margin: 1.5rem 0;
-      padding: 1rem;
-      border: 1px solid #e0e0e0;
-      border-radius: 4px;
+
+    .filmstrip-frame .frame-label {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: rgba(0,0,0,0.55);
+      color: #fff;
+      font-size: 0.6rem;
+      text-align: center;
+      padding: 1px 0;
+      pointer-events: none;
     }
   </style>
 </head>
 <body>
-  <h1>@jsquash/gif Decoder</h1>
-  <form>
-    <label>
-      Choose a GIF file:
-      <input type="file" name="file" accept=".gif,image/gif">
-    </label>
-  </form>
+  <h1>@jsquash/gif <span>Decoder</span></h1>
+  <p class="subtitle">Rust gif crate compiled to WebAssembly via wasm-pack</p>
+
+  <div class="drop-zone" id="drop-zone">
+    <p>Drop a GIF here or click to browse</p>
+    <input type="file" accept=".gif,image/gif">
+  </div>
 
   <div id="status"></div>
 
-  <div class="section" id="single-frame-section" hidden>
-    <h2>Single Frame (decode)</h2>
-    <canvas id="single-canvas"></canvas>
-    <p id="single-info"></p>
+  <div class="card" id="single-frame-section" hidden>
+    <h2>First Frame &mdash; decode()</h2>
+    <div class="canvas-wrap">
+      <canvas id="single-canvas"></canvas>
+    </div>
+    <p class="card-meta" id="single-info"></p>
   </div>
 
-  <div class="section" id="animation-section" hidden>
-    <h2>Animation (decodeAnimated)</h2>
-    <canvas id="anim-canvas"></canvas>
-    <div id="controls">
-      <button id="play-btn">Pause</button>
+  <div class="card" id="animation-section" hidden>
+    <h2>Animation &mdash; decodeAnimated()</h2>
+    <div class="canvas-wrap">
+      <canvas id="anim-canvas"></canvas>
     </div>
-    <p id="frame-info"></p>
+    <div class="controls">
+      <button id="play-btn">Pause</button>
+      <p id="frame-info"></p>
+    </div>
+    <div class="filmstrip" id="filmstrip"></div>
   </div>
 
   <script type="module" src="./main.js"></script>

--- a/examples/gif-decode/index.html
+++ b/examples/gif-decode/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>jSquash GIF Decoder Example</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 800px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+    canvas {
+      border: 1px solid #ccc;
+      display: block;
+      margin: 1rem 0;
+      image-rendering: pixelated;
+    }
+    #status {
+      color: #666;
+      margin: 0.5rem 0;
+    }
+    #controls {
+      margin: 1rem 0;
+    }
+    #controls button {
+      margin-right: 0.5rem;
+    }
+    #frame-info {
+      font-size: 0.9rem;
+      color: #444;
+    }
+    .section {
+      margin: 1.5rem 0;
+      padding: 1rem;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <h1>@jsquash/gif Decoder</h1>
+  <form>
+    <label>
+      Choose a GIF file:
+      <input type="file" name="file" accept=".gif,image/gif">
+    </label>
+  </form>
+
+  <div id="status"></div>
+
+  <div class="section" id="single-frame-section" hidden>
+    <h2>Single Frame (decode)</h2>
+    <canvas id="single-canvas"></canvas>
+    <p id="single-info"></p>
+  </div>
+
+  <div class="section" id="animation-section" hidden>
+    <h2>Animation (decodeAnimated)</h2>
+    <canvas id="anim-canvas"></canvas>
+    <div id="controls">
+      <button id="play-btn">Pause</button>
+    </div>
+    <p id="frame-info"></p>
+  </div>
+
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/examples/gif-decode/main.js
+++ b/examples/gif-decode/main.js
@@ -1,0 +1,93 @@
+import { decode, decodeAnimated, isAnimated } from 'https://unpkg.com/@jsquash/gif@latest?module';
+
+const status = document.getElementById('status');
+const singleSection = document.getElementById('single-frame-section');
+const animSection = document.getElementById('animation-section');
+const singleCanvas = document.getElementById('single-canvas');
+const animCanvas = document.getElementById('anim-canvas');
+const singleInfo = document.getElementById('single-info');
+const frameInfo = document.getElementById('frame-info');
+const playBtn = document.getElementById('play-btn');
+
+let animationId = null;
+let playing = false;
+
+function drawImageData(canvas, imageData) {
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const ctx = canvas.getContext('2d');
+  ctx.putImageData(imageData, 0, 0);
+}
+
+function playAnimation(canvas, frames) {
+  let currentFrame = 0;
+  playing = true;
+  playBtn.textContent = 'Pause';
+
+  function renderFrame() {
+    const frame = frames[currentFrame];
+    drawImageData(canvas, frame.imageData);
+    frameInfo.textContent = `Frame ${currentFrame + 1} / ${frames.length} — ${frame.duration}ms`;
+    currentFrame = (currentFrame + 1) % frames.length;
+    animationId = setTimeout(renderFrame, frame.duration);
+  }
+
+  renderFrame();
+}
+
+function stopAnimation() {
+  if (animationId !== null) {
+    clearTimeout(animationId);
+    animationId = null;
+  }
+  playing = false;
+  playBtn.textContent = 'Play';
+}
+
+playBtn.addEventListener('click', () => {
+  if (playing) {
+    stopAnimation();
+  } else if (playBtn._frames) {
+    playAnimation(animCanvas, playBtn._frames);
+  }
+});
+
+document.querySelector('form').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  stopAnimation();
+  singleSection.hidden = true;
+  animSection.hidden = true;
+  status.textContent = 'Decoding...';
+
+  try {
+    const buffer = await file.arrayBuffer();
+
+    // Single frame decode
+    const t0 = performance.now();
+    const imageData = await decode(buffer);
+    const decodeTime = (performance.now() - t0).toFixed(1);
+    drawImageData(singleCanvas, imageData);
+    singleInfo.textContent = `${imageData.width}x${imageData.height} — decoded in ${decodeTime}ms`;
+    singleSection.hidden = false;
+
+    // Check if animated
+    const animated = await isAnimated(buffer);
+
+    if (animated) {
+      const t1 = performance.now();
+      const frames = await decodeAnimated(buffer);
+      const animTime = (performance.now() - t1).toFixed(1);
+      status.textContent = `Animated GIF: ${frames.length} frames decoded in ${animTime}ms`;
+      playBtn._frames = frames;
+      playAnimation(animCanvas, frames);
+      animSection.hidden = false;
+    } else {
+      status.textContent = `Static GIF — decoded in ${decodeTime}ms`;
+    }
+  } catch (err) {
+    status.textContent = `Error: ${err.message}`;
+    console.error(err);
+  }
+});

--- a/examples/gif-decode/main.js
+++ b/examples/gif-decode/main.js
@@ -1,4 +1,4 @@
-import { decode, decodeAnimated, isAnimated } from 'https://unpkg.com/@jsquash/gif@latest?module';
+import init, { decode, decodeAnimated, isAnimated } from '../../packages/gif/codec/pkg/squoosh_gif.js';
 
 const status = document.getElementById('status');
 const singleSection = document.getElementById('single-frame-section');
@@ -52,6 +52,8 @@ playBtn.addEventListener('click', () => {
   }
 });
 
+let initialized = false;
+
 document.querySelector('form').addEventListener('change', async (e) => {
   const file = e.target.files[0];
   if (!file) return;
@@ -59,25 +61,33 @@ document.querySelector('form').addEventListener('change', async (e) => {
   stopAnimation();
   singleSection.hidden = true;
   animSection.hidden = true;
+  status.textContent = 'Initializing WASM...';
+
+  if (!initialized) {
+    await init();
+    initialized = true;
+  }
+
   status.textContent = 'Decoding...';
 
   try {
     const buffer = await file.arrayBuffer();
+    const data = new Uint8Array(buffer);
 
     // Single frame decode
     const t0 = performance.now();
-    const imageData = await decode(buffer);
+    const imageData = decode(data);
     const decodeTime = (performance.now() - t0).toFixed(1);
     drawImageData(singleCanvas, imageData);
     singleInfo.textContent = `${imageData.width}x${imageData.height} — decoded in ${decodeTime}ms`;
     singleSection.hidden = false;
 
     // Check if animated
-    const animated = await isAnimated(buffer);
+    const animated = isAnimated(data);
 
     if (animated) {
       const t1 = performance.now();
-      const frames = await decodeAnimated(buffer);
+      const frames = decodeAnimated(data);
       const animTime = (performance.now() - t1).toFixed(1);
       status.textContent = `Animated GIF: ${frames.length} frames decoded in ${animTime}ms`;
       playBtn._frames = frames;

--- a/examples/gif-decode/main.js
+++ b/examples/gif-decode/main.js
@@ -1,6 +1,6 @@
 import init, { decode, decodeAnimated, isAnimated } from '../../packages/gif/codec/pkg/squoosh_gif.js';
 
-const status = document.getElementById('status');
+const statusEl = document.getElementById('status');
 const singleSection = document.getElementById('single-frame-section');
 const animSection = document.getElementById('animation-section');
 const singleCanvas = document.getElementById('single-canvas');
@@ -8,9 +8,20 @@ const animCanvas = document.getElementById('anim-canvas');
 const singleInfo = document.getElementById('single-info');
 const frameInfo = document.getElementById('frame-info');
 const playBtn = document.getElementById('play-btn');
+const filmstrip = document.getElementById('filmstrip');
+const dropZone = document.getElementById('drop-zone');
+const fileInput = dropZone.querySelector('input[type="file"]');
 
 let animationId = null;
 let playing = false;
+let currentFrameIndex = 0;
+let initialized = false;
+
+function setStatus(msg, isError = false) {
+  statusEl.style.display = 'block';
+  statusEl.textContent = msg;
+  statusEl.classList.toggle('error', isError);
+}
 
 function drawImageData(canvas, imageData) {
   canvas.width = imageData.width;
@@ -19,16 +30,22 @@ function drawImageData(canvas, imageData) {
   ctx.putImageData(imageData, 0, 0);
 }
 
+function highlightFilmstripFrame(index) {
+  filmstrip.querySelectorAll('.filmstrip-frame').forEach((el, i) => {
+    el.classList.toggle('active', i === index);
+  });
+}
+
 function playAnimation(canvas, frames) {
-  let currentFrame = 0;
   playing = true;
   playBtn.textContent = 'Pause';
 
   function renderFrame() {
-    const frame = frames[currentFrame];
+    const frame = frames[currentFrameIndex];
     drawImageData(canvas, frame.imageData);
-    frameInfo.textContent = `Frame ${currentFrame + 1} / ${frames.length} — ${frame.duration}ms`;
-    currentFrame = (currentFrame + 1) % frames.length;
+    frameInfo.textContent = `Frame ${currentFrameIndex + 1} / ${frames.length} \u2014 ${frame.duration}ms`;
+    highlightFilmstripFrame(currentFrameIndex);
+    currentFrameIndex = (currentFrameIndex + 1) % frames.length;
     animationId = setTimeout(renderFrame, frame.duration);
   }
 
@@ -44,6 +61,48 @@ function stopAnimation() {
   playBtn.textContent = 'Play';
 }
 
+function buildFilmstrip(frames) {
+  filmstrip.innerHTML = '';
+  const thumbHeight = 80;
+
+  frames.forEach((frame, i) => {
+    const aspect = frame.imageData.width / frame.imageData.height;
+    const thumbWidth = Math.round(thumbHeight * aspect);
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'filmstrip-frame';
+
+    const canvas = document.createElement('canvas');
+    canvas.width = thumbWidth;
+    canvas.height = thumbHeight;
+    const ctx = canvas.getContext('2d');
+
+    // Draw scaled-down frame
+    const tmp = document.createElement('canvas');
+    tmp.width = frame.imageData.width;
+    tmp.height = frame.imageData.height;
+    tmp.getContext('2d').putImageData(frame.imageData, 0, 0);
+    ctx.drawImage(tmp, 0, 0, thumbWidth, thumbHeight);
+
+    const label = document.createElement('div');
+    label.className = 'frame-label';
+    label.textContent = `#${i + 1} ${frame.duration}ms`;
+
+    wrapper.appendChild(canvas);
+    wrapper.appendChild(label);
+
+    wrapper.addEventListener('click', () => {
+      stopAnimation();
+      currentFrameIndex = i;
+      drawImageData(animCanvas, frame.imageData);
+      frameInfo.textContent = `Frame ${i + 1} / ${frames.length} \u2014 ${frame.duration}ms`;
+      highlightFilmstripFrame(i);
+    });
+
+    filmstrip.appendChild(wrapper);
+  });
+}
+
 playBtn.addEventListener('click', () => {
   if (playing) {
     stopAnimation();
@@ -52,23 +111,22 @@ playBtn.addEventListener('click', () => {
   }
 });
 
-let initialized = false;
-
-document.querySelector('form').addEventListener('change', async (e) => {
-  const file = e.target.files[0];
-  if (!file) return;
+async function handleFile(file) {
+  if (!file || !file.type.startsWith('image/gif')) return;
 
   stopAnimation();
+  currentFrameIndex = 0;
   singleSection.hidden = true;
   animSection.hidden = true;
-  status.textContent = 'Initializing WASM...';
+  filmstrip.innerHTML = '';
 
   if (!initialized) {
+    setStatus('Initializing WASM...');
     await init();
     initialized = true;
   }
 
-  status.textContent = 'Decoding...';
+  setStatus('Decoding...');
 
   try {
     const buffer = await file.arrayBuffer();
@@ -79,7 +137,7 @@ document.querySelector('form').addEventListener('change', async (e) => {
     const imageData = decode(data);
     const decodeTime = (performance.now() - t0).toFixed(1);
     drawImageData(singleCanvas, imageData);
-    singleInfo.textContent = `${imageData.width}x${imageData.height} — decoded in ${decodeTime}ms`;
+    singleInfo.textContent = `${imageData.width} \u00d7 ${imageData.height} \u2014 decoded in ${decodeTime}ms`;
     singleSection.hidden = false;
 
     // Check if animated
@@ -89,15 +147,32 @@ document.querySelector('form').addEventListener('change', async (e) => {
       const t1 = performance.now();
       const frames = decodeAnimated(data);
       const animTime = (performance.now() - t1).toFixed(1);
-      status.textContent = `Animated GIF: ${frames.length} frames decoded in ${animTime}ms`;
+      setStatus(`Animated GIF: ${frames.length} frames, ${imageData.width}\u00d7${imageData.height} \u2014 decoded in ${animTime}ms`);
       playBtn._frames = frames;
+      buildFilmstrip(frames);
       playAnimation(animCanvas, frames);
       animSection.hidden = false;
     } else {
-      status.textContent = `Static GIF — decoded in ${decodeTime}ms`;
+      setStatus(`Static GIF: ${imageData.width}\u00d7${imageData.height} \u2014 decoded in ${decodeTime}ms`);
     }
   } catch (err) {
-    status.textContent = `Error: ${err.message}`;
+    setStatus(`Error: ${err.message}`, true);
     console.error(err);
   }
+}
+
+// File input
+dropZone.addEventListener('click', () => fileInput.click());
+fileInput.addEventListener('change', (e) => handleFile(e.target.files[0]));
+
+// Drag and drop
+dropZone.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  dropZone.classList.add('dragover');
+});
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropZone.classList.remove('dragover');
+  handleFile(e.dataTransfer.files[0]);
 });

--- a/packages/gif/codec/Cargo.toml
+++ b/packages/gif/codec/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "squoosh-gif"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--no-validation"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gif = "0.13"
+wasm-bindgen = "0.2.89"
+js-sys = "0.3.66"
+web-sys = { version = "0.3.66", features = ["ImageData"] }
+
+[profile.release]
+lto = true
+opt-level = "s"

--- a/packages/gif/codec/package.json
+++ b/packages/gif/codec/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "squoosh-gif",
+  "scripts": {
+    "build": "../../../tools/build-rust.sh && npm run patch-pre-script",
+    "patch-pre-script": "cat pre.js >> pkg/squoosh_gif.js"
+  }
+}

--- a/packages/gif/codec/pre.js
+++ b/packages/gif/codec/pre.js
@@ -1,0 +1,24 @@
+const isServiceWorker = globalThis.ServiceWorkerGlobalScope !== undefined;
+const isRunningInCloudFlareWorkers = isServiceWorker && typeof self !== 'undefined' && globalThis.caches && globalThis.caches.default !== undefined;
+const isRunningInNode = typeof process === 'object' && process.release && process.release.name === 'node';
+
+if (isRunningInCloudFlareWorkers || isRunningInNode) {
+  if (!globalThis.ImageData) {
+    // Simple Polyfill for ImageData Object
+    globalThis.ImageData = class ImageData {
+      constructor(data, width, height) {
+        this.data = data;
+        this.width = width;
+        this.height = height;
+      }
+    };
+  }
+
+  if (import.meta.url === undefined) {
+    import.meta.url = 'https://localhost';
+  }
+
+  if (typeof self !== 'undefined' && self.location === undefined) {
+    self.location = { href: '' };
+  }
+}

--- a/packages/gif/codec/src/lib.rs
+++ b/packages/gif/codec/src/lib.rs
@@ -39,8 +39,21 @@ fn make_image_data(rgba: Vec<u8>, width: u32, height: u32) -> ImageData {
     ImageData::new_with_owned_u8_clamped_array_and_sh(Clamped(rgba), width, height)
 }
 
+fn validate_gif(data: &[u8]) {
+    if data.len() < 6 {
+        wasm_bindgen::throw_str("Not a valid GIF file (too short)");
+    }
+    let sig = &data[..6];
+    if sig != b"GIF87a" && sig != b"GIF89a" {
+        wasm_bindgen::throw_str(
+            "Not a valid GIF file (expected GIF87a/GIF89a header)",
+        );
+    }
+}
+
 #[wasm_bindgen]
 pub fn decode(data: &[u8]) -> ImageData {
+    validate_gif(data);
     let mut opts = DecodeOptions::new();
     opts.set_color_output(gif::ColorOutput::RGBA);
     let mut decoder = opts.read_info(data).unwrap_throw();
@@ -82,6 +95,7 @@ pub fn decode(data: &[u8]) -> ImageData {
 
 #[wasm_bindgen(js_name = "decodeAnimated")]
 pub fn decode_animated(data: &[u8]) -> Vec<GIFFrame> {
+    validate_gif(data);
     let mut opts = DecodeOptions::new();
     opts.set_color_output(gif::ColorOutput::RGBA);
     let mut decoder = opts.read_info(data).unwrap_throw();
@@ -167,6 +181,7 @@ pub fn decode_animated(data: &[u8]) -> Vec<GIFFrame> {
 
 #[wasm_bindgen(js_name = "isAnimated")]
 pub fn is_animated(data: &[u8]) -> bool {
+    validate_gif(data);
     let mut opts = DecodeOptions::new();
     opts.set_color_output(gif::ColorOutput::RGBA);
     let mut decoder = match opts.read_info(data) {

--- a/packages/gif/codec/src/lib.rs
+++ b/packages/gif/codec/src/lib.rs
@@ -1,0 +1,185 @@
+use gif::{DecodeOptions, DisposalMethod};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::{Clamped, JsCast};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = ImageData)]
+    pub type ImageData;
+
+    #[wasm_bindgen(constructor)]
+    fn new_with_owned_u8_clamped_array_and_sh(
+        data: Clamped<Vec<u8>>,
+        sw: u32,
+        sh: u32,
+    ) -> ImageData;
+}
+
+#[wasm_bindgen]
+pub struct GIFFrame {
+    image_data: ImageData,
+    duration: u32,
+}
+
+#[wasm_bindgen]
+impl GIFFrame {
+    #[wasm_bindgen(getter, js_name = "imageData")]
+    pub fn image_data(&self) -> ImageData {
+        let val: JsValue = self.image_data.clone().into();
+        val.unchecked_into()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn duration(&self) -> u32 {
+        self.duration
+    }
+}
+
+fn make_image_data(rgba: Vec<u8>, width: u32, height: u32) -> ImageData {
+    ImageData::new_with_owned_u8_clamped_array_and_sh(Clamped(rgba), width, height)
+}
+
+#[wasm_bindgen]
+pub fn decode(data: &[u8]) -> ImageData {
+    let mut opts = DecodeOptions::new();
+    opts.set_color_output(gif::ColorOutput::RGBA);
+    let mut decoder = opts.read_info(data).unwrap_throw();
+
+    let width = decoder.width() as u32;
+    let height = decoder.height() as u32;
+    let canvas_size = (width * height * 4) as usize;
+
+    let mut canvas = vec![0u8; canvas_size];
+
+    if let Some(frame) = decoder.read_next_frame().unwrap_throw() {
+        let fw = frame.width as u32;
+        let fh = frame.height as u32;
+        let fl = frame.left as u32;
+        let ft = frame.top as u32;
+
+        for y in 0..fh {
+            for x in 0..fw {
+                let src = ((y * fw + x) * 4) as usize;
+                let alpha = frame.buffer[src + 3];
+                if alpha == 0 {
+                    continue;
+                }
+                let dx = fl + x;
+                let dy = ft + y;
+                if dx >= width || dy >= height {
+                    continue;
+                }
+                let dst = ((dy * width + dx) * 4) as usize;
+                canvas[dst..dst + 4].copy_from_slice(&frame.buffer[src..src + 4]);
+            }
+        }
+    } else {
+        wasm_bindgen::throw_str("No frames found in GIF");
+    }
+
+    make_image_data(canvas, width, height)
+}
+
+#[wasm_bindgen(js_name = "decodeAnimated")]
+pub fn decode_animated(data: &[u8]) -> Vec<GIFFrame> {
+    let mut opts = DecodeOptions::new();
+    opts.set_color_output(gif::ColorOutput::RGBA);
+    let mut decoder = opts.read_info(data).unwrap_throw();
+
+    let width = decoder.width() as u32;
+    let height = decoder.height() as u32;
+    let canvas_size = (width * height * 4) as usize;
+
+    let mut canvas = vec![0u8; canvas_size];
+    let mut frames: Vec<GIFFrame> = Vec::new();
+
+    while let Some(frame) = decoder.read_next_frame().unwrap_throw() {
+        let fw = frame.width as u32;
+        let fh = frame.height as u32;
+        let fl = frame.left as u32;
+        let ft = frame.top as u32;
+        let disposal = frame.dispose;
+
+        // Save canvas state before rendering (for restore-to-previous)
+        let prev_canvas = if disposal == DisposalMethod::Previous {
+            Some(canvas.clone())
+        } else {
+            None
+        };
+
+        // Render frame onto canvas
+        for y in 0..fh {
+            for x in 0..fw {
+                let src = ((y * fw + x) * 4) as usize;
+                let alpha = frame.buffer[src + 3];
+                if alpha == 0 {
+                    continue;
+                }
+                let dx = fl + x;
+                let dy = ft + y;
+                if dx >= width || dy >= height {
+                    continue;
+                }
+                let dst = ((dy * width + dx) * 4) as usize;
+                canvas[dst..dst + 4].copy_from_slice(&frame.buffer[src..src + 4]);
+            }
+        }
+
+        // Default delay of 100ms if not specified or zero
+        let delay_ms = if frame.delay == 0 {
+            100
+        } else {
+            frame.delay as u32 * 10
+        };
+
+        let image_data = make_image_data(canvas.clone(), width, height);
+        frames.push(GIFFrame {
+            image_data,
+            duration: delay_ms,
+        });
+
+        // Apply disposal method for next frame
+        match disposal {
+            DisposalMethod::Background => {
+                for y in 0..fh {
+                    for x in 0..fw {
+                        let dx = fl + x;
+                        let dy = ft + y;
+                        if dx >= width || dy >= height {
+                            continue;
+                        }
+                        let dst = ((dy * width + dx) * 4) as usize;
+                        canvas[dst..dst + 4].copy_from_slice(&[0, 0, 0, 0]);
+                    }
+                }
+            }
+            DisposalMethod::Previous => {
+                if let Some(prev) = prev_canvas {
+                    canvas = prev;
+                }
+            }
+            _ => {} // Keep / Any — leave canvas as-is
+        }
+    }
+
+    frames
+}
+
+#[wasm_bindgen(js_name = "isAnimated")]
+pub fn is_animated(data: &[u8]) -> bool {
+    let mut opts = DecodeOptions::new();
+    opts.set_color_output(gif::ColorOutput::RGBA);
+    let mut decoder = match opts.read_info(data) {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+
+    // Read first frame
+    match decoder.read_next_frame() {
+        Ok(Some(_)) => {}
+        _ => return false,
+    }
+
+    // If there's a second frame, it's animated
+    matches!(decoder.read_next_frame(), Ok(Some(_)))
+}

--- a/packages/gif/decode.ts
+++ b/packages/gif/decode.ts
@@ -1,0 +1,62 @@
+import type {
+  GIFFrame,
+  InitInput,
+  InitOutput as GifModule,
+} from './codec/pkg/squoosh_gif.js';
+import initGifModule, {
+  decode as gifDecodeWasm,
+  decodeAnimated as gifDecodeAnimatedWasm,
+  isAnimated as gifIsAnimatedWasm,
+} from './codec/pkg/squoosh_gif.js';
+
+export type { GIFFrame };
+
+let gifModule: Promise<GifModule>;
+
+function validateGif(buffer: ArrayBuffer): void {
+  const header = new Uint8Array(buffer, 0, 6);
+  const sig = String.fromCharCode(...header);
+  if (sig !== 'GIF87a' && sig !== 'GIF89a') {
+    throw new Error(
+      `Not a valid GIF file (expected GIF87a/GIF89a header, got "${sig.replace(/[^\x20-\x7E]/g, '?')}")`,
+    );
+  }
+}
+
+export async function init(moduleOrPath?: InitInput): Promise<GifModule> {
+  if (!gifModule) {
+    gifModule = initGifModule(moduleOrPath);
+  }
+  return gifModule;
+}
+
+export default async function decode(
+  buffer: ArrayBuffer,
+): Promise<ImageData> {
+  validateGif(buffer);
+  await init();
+
+  const result = gifDecodeWasm(new Uint8Array(buffer));
+  if (!result) throw new Error('Decoding error');
+  return result;
+}
+
+export async function decodeAnimated(
+  buffer: ArrayBuffer,
+): Promise<GIFFrame[]> {
+  validateGif(buffer);
+  await init();
+
+  const result = gifDecodeAnimatedWasm(new Uint8Array(buffer));
+  if (!result) throw new Error('Decoding error');
+  return result;
+}
+
+export async function isAnimated(
+  buffer: ArrayBuffer,
+): Promise<boolean> {
+  validateGif(buffer);
+  await init();
+
+  return gifIsAnimatedWasm(new Uint8Array(buffer));
+}

--- a/packages/gif/index.ts
+++ b/packages/gif/index.ts
@@ -1,0 +1,2 @@
+export { default as decode, decodeAnimated, isAnimated } from './decode.js';
+export type { GIFFrame } from './decode.js';

--- a/packages/gif/meta.ts
+++ b/packages/gif/meta.ts
@@ -1,0 +1,3 @@
+export const label = 'GIF';
+export const mimeType = 'image/gif';
+export const extension = 'gif';

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@jsquash/gif",
+  "version": "1.0.0",
+  "main": "index.js",
+  "description": "Wasm GIF decoder supporting the browser. Decode GIF images to ImageData.",
+  "repository": "jamsinclair/jSquash",
+  "author": {
+    "name": "Jamie Sinclair",
+    "email": "jamsinclairnz+npm@gmail.com"
+  },
+  "keywords": [
+    "image",
+    "optimisation",
+    "optimization",
+    "squoosh",
+    "wasm",
+    "webassembly",
+    "gif"
+  ],
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:codec": "cd codec && npm run build",
+    "build": "npm run clean && tsc && cp -r codec package.json README.md .npmignore ../../LICENSE dist && cd dist/codec",
+    "prepublishOnly": "[[ \"$PWD\" == *'/dist' ]] && exit 0 || (echo 'Please run npm publish from the dist directory' && exit 1)"
+  },
+  "devDependencies": {
+    "@types/node": "^20.9.2",
+    "typescript": "^4.4.4"
+  },
+  "type": "module",
+  "sideEffects": false
+}

--- a/packages/gif/tsconfig.json
+++ b/packages/gif/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "downlevelIteration": true,
+    "module": "esnext",
+    "strict": true,
+    "moduleResolution": "node",
+    "composite": true,
+    "declarationMap": true,
+    "baseUrl": "./",
+    "rootDir": "./",
+    "outDir": "dist",
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `@jsquash/gif` decoder package using the Rust `gif` crate (v0.13) compiled to WASM via wasm-pack
- Replaces the C/Emscripten giflib approach from #102  with a Rust implementation that follows the same patterns as the existing `png` and `oxipng` packages
- Supports three methods: `decode` (first frame → ImageData), `decodeAnimated` (all frames with timing/disposal), and `isAnimated` (quick multi-frame check)
- WASM binary is only 38KB (release + LTO + size-optimized)

## Changes
- `codec/Cargo.toml` — Rust crate config with `gif`, `wasm-bindgen`, `js-sys`, `web-sys` deps
- `codec/src/lib.rs` — GIF decoder with full animation support (frame disposal methods, transparency, delay handling)
- `codec/package.json` + `codec/pre.js` — Build scripts and Node/CloudFlare Workers polyfills (matches png/oxipng pattern)
- `decode.ts` — TypeScript wrapper with lazy WASM init, GIF header validation
- `index.ts`, `meta.ts`, `package.json`, `tsconfig.json` — Package scaffolding


