### PR TITLE
docs: add GIF to animated WebP converter example

### DIFF
--- a/examples/gif-to-webp/index.html
+++ b/examples/gif-to-webp/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GIF to Animated WebP Converter</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+      background: #f8f9fa;
+      color: #1a1a1a;
+    }
+
+    h1 { font-size: 1.5rem; font-weight: 600; margin: 0 0 0.25rem; }
+    h1 span { color: #666; font-weight: 400; }
+
+    .subtitle {
+      color: #888;
+      font-size: 0.85rem;
+      margin: 0 0 1.5rem;
+    }
+
+    .drop-zone {
+      border: 2px dashed #ccc;
+      border-radius: 8px;
+      padding: 2.5rem;
+      text-align: center;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      background: #fff;
+    }
+
+    .drop-zone:hover, .drop-zone.dragover {
+      border-color: #4a90d9;
+      background: #f0f6ff;
+    }
+
+    .drop-zone p { margin: 0; color: #666; font-size: 0.95rem; }
+    .drop-zone input[type="file"] { display: none; }
+
+    #status {
+      margin: 1rem 0;
+      padding: 0.6rem 1rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      background: #e8f4fd;
+      color: #1a6fa8;
+      display: none;
+    }
+
+    #status.error { background: #fde8e8; color: #a81a1a; }
+    #status.success { background: #e8fde8; color: #1a8a2e; }
+
+    .options {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin: 1rem 0;
+      display: none;
+    }
+
+    .options h2 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #555;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin: 0 0 0.75rem;
+    }
+
+    .options label {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: #444;
+      margin-bottom: 0.5rem;
+    }
+
+    .options input[type="range"] { flex: 1; max-width: 200px; }
+    .options .value { font-variant-numeric: tabular-nums; min-width: 2.5em; }
+
+    .convert-btn {
+      padding: 0.5rem 1.5rem;
+      border: none;
+      border-radius: 6px;
+      background: #4a90d9;
+      color: #fff;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: background 0.15s;
+      margin-top: 0.5rem;
+    }
+
+    .convert-btn:hover { background: #3a7bc8; }
+    .convert-btn:disabled { background: #a0c4e8; cursor: not-allowed; }
+
+    .comparison {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin: 1rem 0;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+
+    .card h2 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #555;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin: 0 0 0.75rem;
+    }
+
+    .card-meta {
+      font-size: 0.8rem;
+      color: #888;
+      margin: 0.5rem 0 0;
+    }
+
+    .preview-wrap {
+      background: repeating-conic-gradient(#e8e8e8 0% 25%, #fff 0% 50%) 0 0 / 16px 16px;
+      border-radius: 4px;
+      padding: 0.5rem;
+      display: flex;
+      justify-content: center;
+      min-height: 100px;
+      overflow: auto;
+    }
+
+    .preview-wrap img, .preview-wrap canvas {
+      max-width: 100%;
+      height: auto;
+      image-rendering: pixelated;
+    }
+
+    .download-btn {
+      display: inline-block;
+      margin-top: 0.5rem;
+      padding: 0.35rem 1rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 0.8rem;
+      text-decoration: none;
+      color: #1a1a1a;
+      transition: background 0.1s;
+    }
+
+    .download-btn:hover { background: #f3f4f6; }
+
+    @media (max-width: 640px) {
+      .comparison { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <h1>GIF <span>to</span> Animated WebP</h1>
+  <p class="subtitle">Decode GIF with Rust gif crate, encode to animated WebP with libwebp -- all in the browser via WASM</p>
+
+  <div class="drop-zone" id="drop-zone">
+    <p>Drop a GIF here or click to browse</p>
+    <input type="file" accept=".gif,image/gif">
+  </div>
+
+  <div id="status"></div>
+
+  <div class="options" id="options">
+    <h2>WebP Options</h2>
+    <label>
+      Quality
+      <input type="range" id="quality" min="0" max="100" value="75">
+      <span class="value" id="quality-value">75</span>
+    </label>
+    <label>
+      Method (0=fast, 6=best)
+      <input type="range" id="method" min="0" max="6" value="4">
+      <span class="value" id="method-value">4</span>
+    </label>
+    <button class="convert-btn" id="convert-btn" disabled>Convert to WebP</button>
+  </div>
+
+  <div class="comparison" id="comparison" style="display:none">
+    <div class="card">
+      <h2>Source GIF</h2>
+      <div class="preview-wrap">
+        <img id="gif-preview">
+      </div>
+      <p class="card-meta" id="gif-meta"></p>
+    </div>
+    <div class="card">
+      <h2>Output WebP</h2>
+      <div class="preview-wrap">
+        <img id="webp-preview">
+      </div>
+      <p class="card-meta" id="webp-meta"></p>
+      <a class="download-btn" id="download-btn" style="display:none">Download .webp</a>
+    </div>
+  </div>
+
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/examples/gif-to-webp/main.js
+++ b/examples/gif-to-webp/main.js
@@ -1,0 +1,178 @@
+import gifInit, {
+  decodeAnimated as gifDecodeAnimated,
+  decode as gifDecode,
+  isAnimated as gifIsAnimated,
+} from '../../packages/gif/codec/pkg/squoosh_gif.js';
+
+import webpEncInit from '../../packages/webp/codec/enc/webp_enc.js';
+
+const dropZone = document.getElementById('drop-zone');
+const fileInput = dropZone.querySelector('input[type="file"]');
+const statusEl = document.getElementById('status');
+const optionsEl = document.getElementById('options');
+const convertBtn = document.getElementById('convert-btn');
+const comparison = document.getElementById('comparison');
+const gifPreview = document.getElementById('gif-preview');
+const webpPreview = document.getElementById('webp-preview');
+const gifMeta = document.getElementById('gif-meta');
+const webpMeta = document.getElementById('webp-meta');
+const downloadBtn = document.getElementById('download-btn');
+const qualityInput = document.getElementById('quality');
+const qualityValue = document.getElementById('quality-value');
+const methodInput = document.getElementById('method');
+const methodValue = document.getElementById('method-value');
+
+let gifBuffer = null;
+let gifFileName = '';
+let gifInitialized = false;
+let webpModule = null;
+
+function setStatus(msg, type = 'info') {
+  statusEl.style.display = 'block';
+  statusEl.textContent = msg;
+  statusEl.className = type === 'error' ? 'error' : type === 'success' ? 'success' : '';
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+qualityInput.addEventListener('input', () => { qualityValue.textContent = qualityInput.value; });
+methodInput.addEventListener('input', () => { methodValue.textContent = methodInput.value; });
+
+async function initGif() {
+  if (!gifInitialized) {
+    await gifInit();
+    gifInitialized = true;
+  }
+}
+
+async function initWebpEnc() {
+  if (!webpModule) {
+    webpModule = await webpEncInit({ noInitialRun: true });
+  }
+  return webpModule;
+}
+
+async function handleFile(file) {
+  if (!file) return;
+
+  gifBuffer = await file.arrayBuffer();
+  gifFileName = file.name.replace(/\.gif$/i, '');
+  comparison.style.display = 'none';
+  downloadBtn.style.display = 'none';
+
+  // Show GIF preview using native <img>
+  const gifUrl = URL.createObjectURL(file);
+  gifPreview.src = gifUrl;
+
+  setStatus('Initializing WASM decoders...');
+  await initGif();
+
+  const data = new Uint8Array(gifBuffer);
+  const animated = gifIsAnimated(data);
+  const frames = animated ? gifDecodeAnimated(data) : null;
+  const frameCount = frames ? frames.length : 1;
+
+  gifMeta.textContent = `${formatBytes(gifBuffer.byteLength)} \u2014 ${frameCount} frame${frameCount > 1 ? 's' : ''}`;
+
+  optionsEl.style.display = 'block';
+  convertBtn.disabled = false;
+  setStatus(`GIF loaded: ${frameCount} frame${frameCount > 1 ? 's' : ''}. Adjust options and click Convert.`);
+}
+
+convertBtn.addEventListener('click', async () => {
+  if (!gifBuffer) return;
+  convertBtn.disabled = true;
+
+  try {
+    setStatus('Initializing WebP encoder...');
+    const module = await initWebpEnc();
+
+    setStatus('Decoding GIF frames...');
+    const data = new Uint8Array(gifBuffer);
+    const animated = gifIsAnimated(data);
+
+    const quality = parseInt(qualityInput.value);
+    const method = parseInt(methodInput.value);
+
+    // Build default options matching packages/webp/meta.ts
+    const encodeOptions = {
+      quality,
+      target_size: 0,
+      target_PSNR: 0,
+      method,
+      sns_strength: 50,
+      filter_strength: 60,
+      filter_sharpness: 0,
+      filter_type: 1,
+      partitions: 0,
+      segments: 4,
+      pass: 1,
+      show_compressed: 0,
+      preprocessing: 0,
+      autofilter: 0,
+      partition_limit: 0,
+      alpha_compression: 1,
+      alpha_filtering: 1,
+      alpha_quality: 100,
+      lossless: 0,
+      exact: 0,
+      image_hint: 0,
+      emulate_jpeg_size: 0,
+      thread_level: 0,
+      low_memory: 0,
+      near_lossless: 100,
+      use_delta_palette: 0,
+      use_sharp_yuv: 0,
+    };
+
+    let result;
+    const t0 = performance.now();
+
+    if (animated) {
+      const frames = gifDecodeAnimated(data);
+      setStatus(`Encoding ${frames.length} frames to animated WebP...`);
+      result = module.encodeAnimated(frames, encodeOptions);
+    } else {
+      const imageData = gifDecode(data);
+      setStatus('Encoding to WebP...');
+      result = module.encode(imageData.data, imageData.width, imageData.height, encodeOptions);
+    }
+
+    const elapsed = (performance.now() - t0).toFixed(0);
+
+    if (!result) throw new Error('WebP encoding failed');
+
+    const webpBlob = new Blob([result], { type: 'image/webp' });
+    const webpUrl = URL.createObjectURL(webpBlob);
+    webpPreview.src = webpUrl;
+
+    const ratio = ((1 - result.byteLength / gifBuffer.byteLength) * 100).toFixed(1);
+    const sign = ratio >= 0 ? 'smaller' : 'larger';
+    webpMeta.textContent = `${formatBytes(result.byteLength)} \u2014 ${Math.abs(ratio)}% ${sign} \u2014 encoded in ${elapsed}ms`;
+
+    downloadBtn.href = webpUrl;
+    downloadBtn.download = `${gifFileName}.webp`;
+    downloadBtn.style.display = 'inline-block';
+
+    comparison.style.display = '';
+    setStatus(`Done! Converted in ${elapsed}ms.`, 'success');
+  } catch (err) {
+    setStatus(`Error: ${err.message}`, 'error');
+    console.error(err);
+  } finally {
+    convertBtn.disabled = false;
+  }
+});
+
+// File input
+dropZone.addEventListener('click', () => fileInput.click());
+fileInput.addEventListener('change', (e) => handleFile(e.target.files[0]));
+
+// Drag and drop
+dropZone.addEventListener('dragover', (e) => { e.preventDefault(); dropZone.classList.add('dragover'); });
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', (e) => { e.preventDefault(); dropZone.classList.remove('dragover'); handleFile(e.dataTransfer.files[0]); });


### PR DESCRIPTION
## Summary
- Adds an interactive example page (`examples/gif-to-webp/`) that converts GIF files to animated WebP entirely in the browser via WASM
- Decodes GIF frames using `@jsquash/gif` (Rust gif crate) and re-encodes to animated WebP using `@jsquash/webp` (libwebp)
- Includes quality/method controls, drag-and-drop input, side-by-side preview with file size comparison, and a download button

## Dependencies
This PR depends on the following PRs being merged first:
- #103 — Animated WebP encoding/decoding support
- #104 — GIF decoder using Rust gif crate