### PR TITLE
feat: add animated AVIF encoding and decoding support

### DIFF
--- a/packages/avif/codec/dec/avif_dec.cpp
+++ b/packages/avif/codec/dec/avif_dec.cpp
@@ -8,6 +8,7 @@ thread_local const val Uint8ClampedArray = val::global("Uint8ClampedArray");
 thread_local const val Uint16Array = val::global("Uint16Array");
 thread_local const val ImageData = val::global("ImageData");
 thread_local const val Object = val::global("Object");
+thread_local const val Array = val::global("Array");
 
 val decode(std::string avifimage, uint32_t bitDepth = 8) {
   avifImage* image = avifImageCreateEmpty();
@@ -57,6 +58,71 @@ val decode(std::string avifimage, uint32_t bitDepth = 8) {
   return result;
 }
 
+bool isAnimated(std::string avifimage) {
+  avifDecoder* decoder = avifDecoderCreate();
+  avifResult setIOResult = avifDecoderSetIOMemory(
+      decoder, (const uint8_t*)avifimage.c_str(), avifimage.length());
+  if (setIOResult != AVIF_RESULT_OK) {
+    avifDecoderDestroy(decoder);
+    return false;
+  }
+
+  avifResult parseResult = avifDecoderParse(decoder);
+  if (parseResult != AVIF_RESULT_OK) {
+    avifDecoderDestroy(decoder);
+    return false;
+  }
+
+  bool result = decoder->imageCount > 1;
+  avifDecoderDestroy(decoder);
+  return result;
+}
+
+val decodeAnimated(std::string avifimage) {
+  avifDecoder* decoder = avifDecoderCreate();
+  avifResult setIOResult = avifDecoderSetIOMemory(
+      decoder, (const uint8_t*)avifimage.c_str(), avifimage.length());
+  if (setIOResult != AVIF_RESULT_OK) {
+    avifDecoderDestroy(decoder);
+    return val::null();
+  }
+
+  avifResult parseResult = avifDecoderParse(decoder);
+  if (parseResult != AVIF_RESULT_OK) {
+    avifDecoderDestroy(decoder);
+    return val::null();
+  }
+
+  val frames = Array.new_();
+
+  while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
+    avifRGBImage rgb;
+    avifRGBImageSetDefaults(&rgb, decoder->image);
+    rgb.depth = 8;
+    avifRGBImageAllocatePixels(&rgb);
+    avifImageYUVToRGB(decoder->image, &rgb);
+
+    val imageData = ImageData.new_(
+        Uint8ClampedArray.new_(typed_memory_view(rgb.rowBytes * rgb.height, rgb.pixels)),
+        rgb.width, rgb.height);
+
+    // Duration is in seconds, convert to milliseconds
+    int durationMs = (int)(decoder->imageTiming.duration * 1000.0);
+
+    val frameObj = Object.new_();
+    frameObj.set("imageData", imageData);
+    frameObj.set("duration", durationMs);
+    frames.call<void>("push", frameObj);
+
+    avifRGBImageFreePixels(&rgb);
+  }
+
+  avifDecoderDestroy(decoder);
+  return frames;
+}
+
 EMSCRIPTEN_BINDINGS(my_module) {
   function("decode", &decode);
+  function("decodeAnimated", &decodeAnimated);
+  function("isAnimated", &isAnimated);
 }

--- a/packages/avif/codec/dec/avif_dec.d.ts
+++ b/packages/avif/codec/dec/avif_dec.d.ts
@@ -1,7 +1,14 @@
+export interface AVIFAnimFrame {
+  imageData: ImageData;
+  duration: number;
+}
+
 export interface AVIFModule extends EmscriptenWasm.Module {
   decode(data: BufferSource, bitDepth: 10 | 12 | 16): { data: Uint16Array, height: number, width: number } | null;
   decode(data: BufferSource, bitDepth: 8): ImageData | null;
   decode(data: BufferSource, bitDepth: 8 | 10 | 12 | 16): { data: Uint16Array, height: number, width: number } | ImageData | null;
+  decodeAnimated(data: BufferSource): AVIFAnimFrame[] | null;
+  isAnimated(data: BufferSource): boolean;
 }
 
 declare var moduleFactory: EmscriptenWasm.ModuleFactory<AVIFModule>;

--- a/packages/avif/codec/enc/avif_enc.cpp
+++ b/packages/avif/codec/enc/avif_enc.cpp
@@ -168,6 +168,140 @@ val encode(std::string buffer, int width, int height, AvifOptions options) {
   return js_result;
 }
 
+val encodeAnimated(val frames, AvifOptions options) {
+  int frameCount = frames["length"].as<int>();
+  if (frameCount < 1) return val::null();
+
+  avifResult status;
+
+  int depth = options.bitDepth;
+  if (depth != 8 && depth != 10 && depth != 12) {
+    return val::null();
+  }
+
+  avifPixelFormat format;
+  switch (options.subsample) {
+    case 0:
+      format = AVIF_PIXEL_FORMAT_YUV400;
+      break;
+    case 1:
+      format = AVIF_PIXEL_FORMAT_YUV420;
+      break;
+    case 2:
+      format = AVIF_PIXEL_FORMAT_YUV422;
+      break;
+    case 3:
+      format = AVIF_PIXEL_FORMAT_YUV444;
+      break;
+    default:
+      format = AVIF_PIXEL_FORMAT_YUV420;
+      break;
+  }
+
+  bool lossless = options.quality == AVIF_QUALITY_LOSSLESS &&
+                  (options.qualityAlpha == -1 || options.qualityAlpha == AVIF_QUALITY_LOSSLESS) &&
+                  format == AVIF_PIXEL_FORMAT_YUV444;
+
+  // Create encoder
+  AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  RETURN_NULL_IF(encoder == nullptr);
+
+  // Set timescale to 1000 so duration values are in milliseconds
+  encoder->timescale = 1000;
+  encoder->maxThreads = emscripten_num_logical_cores();
+  encoder->tileRowsLog2 = options.tileRowsLog2;
+  encoder->tileColsLog2 = options.tileColsLog2;
+  encoder->speed = options.speed;
+
+  if (lossless) {
+    encoder->quality = AVIF_QUALITY_LOSSLESS;
+    encoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
+  } else {
+    status = avifEncoderSetCodecSpecificOption(encoder.get(), "sharpness",
+                                               std::to_string(options.sharpness).c_str());
+    RETURN_NULL_IF(status != AVIF_RESULT_OK);
+
+    encoder->quality = options.quality;
+    if (options.qualityAlpha == -1) {
+      encoder->qualityAlpha = options.quality;
+    } else {
+      encoder->qualityAlpha = options.qualityAlpha;
+    }
+
+    if (options.tune == 2 || (options.tune == 0 && options.quality >= 50)) {
+      status = avifEncoderSetCodecSpecificOption(encoder.get(), "tune", "ssim");
+      RETURN_NULL_IF(status != AVIF_RESULT_OK);
+    }
+
+    if (options.chromaDeltaQ) {
+      status = avifEncoderSetCodecSpecificOption(encoder.get(), "color:enable-chroma-deltaq", "1");
+      RETURN_NULL_IF(status != AVIF_RESULT_OK);
+    }
+
+    status = avifEncoderSetCodecSpecificOption(encoder.get(), "color:denoise-noise-level",
+                                               std::to_string(options.denoiseLevel).c_str());
+    RETURN_NULL_IF(status != AVIF_RESULT_OK);
+  }
+
+  for (int i = 0; i < frameCount; i++) {
+    val frame = frames[i];
+    val imageData = frame["imageData"];
+    int duration = frame["duration"].as<int>();
+    int width = imageData["width"].as<int>();
+    int height = imageData["height"].as<int>();
+
+    // Get pixel data
+    std::string pixels = imageData["data"]["buffer"].as<std::string>();
+
+    AvifImagePtr image(avifImageCreate(width, height, depth, format), avifImageDestroy);
+    RETURN_NULL_IF(image == nullptr);
+
+    if (lossless) {
+      image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+    } else {
+      image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
+    }
+
+    // Set frame duration in timescale units (milliseconds since timescale=1000)
+    image->duration = duration;
+
+    avifRGBImage srcRGB;
+    avifRGBImageSetDefaults(&srcRGB, image.get());
+
+    uint8_t* rgba = reinterpret_cast<uint8_t*>(const_cast<char*>(pixels.data()));
+    srcRGB.pixels = rgba;
+
+    if (depth > 8) {
+      srcRGB.depth = depth;
+      srcRGB.rowBytes = width * 8;
+    } else {
+      srcRGB.depth = 8;
+      srcRGB.rowBytes = width * 4;
+    }
+
+    if (options.enableSharpYUV) {
+      srcRGB.chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV;
+    }
+
+    status = avifImageRGBToYUV(image.get(), &srcRGB);
+    RETURN_NULL_IF(status != AVIF_RESULT_OK);
+
+    avifAddImageFlags addFlags = AVIF_ADD_IMAGE_FLAG_NONE;
+    status = avifEncoderAddImage(encoder.get(), image.get(), duration, addFlags);
+    RETURN_NULL_IF(status != AVIF_RESULT_OK);
+  }
+
+  avifRWData output = AVIF_DATA_EMPTY;
+  status = avifEncoderFinish(encoder.get(), &output);
+  auto js_result = val::null();
+  if (status == AVIF_RESULT_OK) {
+    js_result = Uint8Array.new_(typed_memory_view(output.size, output.data));
+  }
+
+  avifRWDataFree(&output);
+  return js_result;
+}
+
 EMSCRIPTEN_BINDINGS(my_module) {
   value_object<AvifOptions>("AvifOptions")
       .field("quality", &AvifOptions::quality)
@@ -184,4 +318,5 @@ EMSCRIPTEN_BINDINGS(my_module) {
       .field("bitDepth", &AvifOptions::bitDepth);
 
   function("encode", &encode);
+  function("encodeAnimated", &encodeAnimated);
 }

--- a/packages/avif/codec/enc/avif_enc.d.ts
+++ b/packages/avif/codec/enc/avif_enc.d.ts
@@ -19,11 +19,20 @@ export interface EncodeOptions {
   bitDepth: number;
 }
 
+export type AVIFAnimFrame = {
+  imageData: ImageData;
+  duration: number;
+};
+
 export interface AVIFModule extends EmscriptenWasm.Module {
   encode(
     data: BufferSource,
     width: number,
     height: number,
+    options: EncodeOptions,
+  ): Uint8Array | null;
+  encodeAnimated(
+    frames: AVIFAnimFrame[],
     options: EncodeOptions,
   ): Uint8Array | null;
 }

--- a/packages/avif/decode.ts
+++ b/packages/avif/decode.ts
@@ -16,11 +16,13 @@
  * and modified it to decode JPEG images.
  */
 
-import type { AVIFModule } from './codec/dec/avif_dec.js';
+import type { AVIFModule, AVIFAnimFrame } from './codec/dec/avif_dec.js';
 import { initEmscriptenModule } from './utils.js';
 
 import avif_dec from './codec/dec/avif_dec.js';
 import { ImageData16bit } from 'meta.js';
+
+export type { AVIFAnimFrame };
 
 let emscriptenModule: Promise<AVIFModule>;
 
@@ -76,4 +78,28 @@ export default async function decode(
   const result = module.decode(buffer, bitDepth);
   if (!result) throw new Error('Decoding error');
   return result;
+}
+
+export async function decodeAnimated(
+  buffer: ArrayBuffer,
+): Promise<AVIFAnimFrame[]> {
+  if (!emscriptenModule) {
+    init();
+  }
+
+  const module = await emscriptenModule;
+  const result = module.decodeAnimated(buffer);
+  if (!result) throw new Error('Decoding error');
+  return result;
+}
+
+export async function isAnimated(
+  buffer: ArrayBuffer,
+): Promise<boolean> {
+  if (!emscriptenModule) {
+    init();
+  }
+
+  const module = await emscriptenModule;
+  return module.isAnimated(buffer);
 }

--- a/packages/avif/encode.ts
+++ b/packages/avif/encode.ts
@@ -17,11 +17,13 @@
  * The avif options are defaulted to defaults from the meta.ts file.
  */
 import type { EncodeOptions, ImageData16bit } from './meta.js';
-import type { AVIFModule } from './codec/enc/avif_enc.js';
+import type { AVIFModule, AVIFAnimFrame } from './codec/enc/avif_enc.js';
 
 import { defaultOptions } from './meta.js';
 import { initEmscriptenModule } from './utils.js';
 import { threads } from 'wasm-feature-detect';
+
+export type { AVIFAnimFrame };
 
 let emscriptenModule: Promise<AVIFModule>;
 
@@ -134,6 +136,37 @@ export default async function encode(
     data.height,
     _options,
   );
+
+  if (!output) {
+    throw new Error('Encoding error.');
+  }
+
+  return output.buffer;
+}
+
+export async function encodeAnimated(
+  frames: AVIFAnimFrame[],
+  options: Partial<EncodeOptions> = {},
+): Promise<ArrayBuffer> {
+  if (!emscriptenModule) emscriptenModule = init();
+  const _options = { ...defaultOptions, ...options };
+
+  if (
+    _options.bitDepth !== 8 &&
+    _options.bitDepth !== 10 &&
+    _options.bitDepth !== 12
+  ) {
+    throw new Error('Invalid bit depth. Supported values are 8, 10, or 12.');
+  }
+
+  if (_options.lossless) {
+    _options.quality = 100;
+    _options.qualityAlpha = -1;
+    _options.subsample = 3;
+  }
+
+  const module = await emscriptenModule;
+  const output = module.encodeAnimated(frames, _options);
 
   if (!output) {
     throw new Error('Encoding error.');

--- a/packages/avif/index.ts
+++ b/packages/avif/index.ts
@@ -1,2 +1,4 @@
-export { default as encode } from './encode.js';
-export { default as decode } from './decode.js';
+export { default as encode, encodeAnimated } from './encode.js';
+export { default as decode, decodeAnimated, isAnimated } from './decode.js';
+export type { AVIFAnimFrame } from './encode.js';
+


### PR DESCRIPTION
## Summary

- Add `decodeAnimated()` and `isAnimated()` functions to the AVIF decoder using libavif's `avifDecoder` with frame iteration (`avifDecoderNextImage`), returning `{imageData, duration}` frame objects with durations in milliseconds
- Add `encodeAnimated()` function to the AVIF encoder using `avifEncoderAddImage()` per frame with `avifEncoderFinish()`, with `encoder->timescale = 1000` for millisecond-based durations
- Export `AVIFAnimFrame` type and all new functions from the package index, following the same pattern as the animated WebP implementation

## Test plan

- [ ] Build the AVIF WASM modules to verify C++ compiles correctly
- [ ] Test `isAnimated()` with a static AVIF (should return `false`) and an animated AVIF (should return `true`)
- [ ] Test `decodeAnimated()` with an animated AVIF file and verify frame count, durations, and pixel data
- [ ] Test `encodeAnimated()` by round-tripping: decode an animated AVIF, re-encode it, and verify the output is valid
- [ ] Test that the existing `decode()` and `encode()` functions still work unchanged for static images

🤖 Generated with [Claude Code](https://claude.com/claude-code)